### PR TITLE
Habilita rota para baixar os pagamentos de subscription

### DIFF
--- a/lib/asaas/api/base.rb
+++ b/lib/asaas/api/base.rb
@@ -22,37 +22,41 @@ module Asaas
       end
 
       def get(id)
-        request(:get, {id: id})
+        request(:get, parse_url(id), {id: id})
         parse_response
       end
 
       def list(params = {})
-        request(:get, params)
+        request(:get, parse_url, params)
         parse_response
       end
 
       def create(attrs)
-        request(:post, {}, attrs)
+        request(:post, parse_url, {}, attrs)
         parse_response
       end
 
       def update(attrs)
-        request(:post, {id: attrs.id}, attrs)
+        request(:post, parse_url(attrs.id), {id: attrs.id}, attrs)
         parse_response
       end
 
       def delete(id)
-        request(:delete, {id: id})
+        request(:delete, parse_url(id), {id: id})
         parse_response
       end
 
       protected
       def parse_url(id = nil)
-        u = URI(@endpoint + @route)
+        u = resource_uri
         if id
           u.path += "/#{id}"
         end
         u.to_s
+      end
+
+      def resource_uri
+        URI(@endpoint + @route)
       end
 
       def parse_response
@@ -85,12 +89,12 @@ module Asaas
         Asaas::Entity::Base
       end
 
-      def request(method, params = {}, body = nil)
+      def request(method, url, params = {}, body = nil)
         body = body.to_h
         body = body.delete_if { |k, v| v.nil? || v.to_s.empty? }
         body = body.to_json
         @response = Typhoeus::Request.new(
-            parse_url(params.fetch(:id, false)),
+            url,
             method: method,
             body: body,
             params: params,

--- a/lib/asaas/api/subscription.rb
+++ b/lib/asaas/api/subscription.rb
@@ -6,6 +6,13 @@ module Asaas
         super(token, api_version, '/subscriptions')
       end
 
+      def payments(subscription_id)
+        url = parse_url(subscription_id) + '/payments'
+
+        request(:get, url, {})
+        parse_response
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Proposta

Esse PR visa adicionar uma nova rota ao client de subscriptions referente aos pagamentos de uma assinatura. 

A partir do id de uma assinatura será possível baixar todos os pagamentos efetuados e a serem realizados por ela. 

## Refatoração

Foi necessário refatorar o `api/base` para aceitar novas rotas pois antes ele só respondia as rotas resful padrão, não permitindo requests em rotas com paths direntes como é o casa das subscriptions. `subscriptions/:id/payments` 