### PR TITLE
Atualizando a versão do activesupport

### DIFF
--- a/asaas-ruby.gemspec
+++ b/asaas-ruby.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "webmock", "~> 3.7.2"
-  
 
-  spec.add_dependency "activesupport", '>= 4.2', "< 6"
+
+  spec.add_dependency "activesupport", "6.0.2.1"
   spec.add_dependency "virtus", '~> 1.0', "~> 1.0.5"
   spec.add_dependency "dry-types", '0.15.0'
   spec.add_dependency "dry-struct", '0.7.0'


### PR DESCRIPTION
Essa atualização foi necessária para corrigir conflitos no uso da gem com Rails 6